### PR TITLE
Add MultiTask detection head

### DIFF
--- a/tests/test_multitask.py
+++ b/tests/test_multitask.py
@@ -1,0 +1,13 @@
+import torch
+from ultralytics.nn.modules.head import MultiTaskDetect
+
+def test_multitask_detect_forward():
+    ch = (64, 128, 256)
+    head = MultiTaskDetect(nc_list=[2, 3], ch=ch)
+    sizes = [80, 40, 20]
+    x = [torch.randn(1, c, sizes[i], sizes[i]) for i, c in enumerate(ch)]
+    head.eval()
+    outputs = head(x)
+    assert isinstance(outputs, list)
+    assert len(outputs) == 2
+

--- a/ultralytics/cfg/models/v8/yolov8-multitask.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-multitask.yaml
@@ -1,0 +1,47 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLOv8 object detection model with P3-P5 outputs. For Usage examples see https://docs.ultralytics.com/tasks/detect
+
+# Parameters
+nc_list: [3, 5] # classes per task
+nc: 8
+scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call yolov8.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024] # YOLOv8n summary: 225 layers,  3157200 parameters,  3157184 gradients,   8.9 GFLOPs
+  s: [0.33, 0.50, 1024] # YOLOv8s summary: 225 layers, 11166560 parameters, 11166544 gradients,  28.8 GFLOPs
+  m: [0.67, 0.75, 768] # YOLOv8m summary: 295 layers, 25902640 parameters, 25902624 gradients,  79.3 GFLOPs
+  l: [1.00, 1.00, 512] # YOLOv8l summary: 365 layers, 43691520 parameters, 43691504 gradients, 165.7 GFLOPs
+  x: [1.00, 1.25, 512] # YOLOv8x summary: 365 layers, 68229648 parameters, 68229632 gradients, 258.5 GFLOPs
+
+# YOLOv8.0n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]] # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]] # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]] # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]] # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]] # 9
+
+# YOLOv8.0n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 6], 1, Concat, [1]] # cat backbone P4
+  - [-1, 3, C2f, [512]] # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 4], 1, Concat, [1]] # cat backbone P3
+  - [-1, 3, C2f, [256]] # 15 (P3/8-small)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]] # cat head P4
+  - [-1, 3, C2f, [512]] # 18 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]] # cat head P5
+  - [-1, 3, C2f, [1024]] # 21 (P5/32-large)
+
+  - [[15, 18, 21], 1, MultiTaskDetect, [[3, 5]]] # Multi-task detect head

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -72,7 +72,17 @@ from .conv import (
     RepConv,
     SpatialAttention,
 )
-from .head import OBB, Classify, Detect, Pose, RTDETRDecoder, Segment, WorldDetect, v10Detect
+from .head import (
+    OBB,
+    Classify,
+    Detect,
+    Pose,
+    RTDETRDecoder,
+    Segment,
+    WorldDetect,
+    v10Detect,
+    MultiTaskDetect,
+)
 from .transformer import (
     AIFI,
     MLP,
@@ -141,6 +151,7 @@ __all__ = (
     "OBB",
     "WorldDetect",
     "v10Detect",
+    "MultiTaskDetect",
     "ImagePoolingAttn",
     "ContrastiveHead",
     "BNContrastiveHead",

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -15,7 +15,16 @@ from .conv import Conv, DWConv
 from .transformer import MLP, DeformableTransformerDecoder, DeformableTransformerDecoderLayer
 from .utils import bias_init_with_prob, linear_init
 
-__all__ = "Detect", "Segment", "Pose", "Classify", "OBB", "RTDETRDecoder", "v10Detect"
+__all__ = (
+    "Detect",
+    "Segment",
+    "Pose",
+    "Classify",
+    "OBB",
+    "RTDETRDecoder",
+    "v10Detect",
+    "MultiTaskDetect",
+)
 
 
 class Detect(nn.Module):
@@ -618,3 +627,21 @@ class v10Detect(Detect):
             for x in ch
         )
         self.one2one_cv3 = copy.deepcopy(self.cv3)
+
+
+class MultiTaskDetect(nn.Module):
+    """Wrapper to run multiple Detect heads for multi-task detection."""
+
+    def __init__(self, nc_list=(80,), ch=()):
+        """Create multiple Detect heads given a list of class counts."""
+        super().__init__()
+        self.heads = nn.ModuleList([Detect(nc=nc, ch=ch) for nc in nc_list])
+
+    def forward(self, x):
+        """Return list of outputs from each Detect head."""
+        outputs = []
+        for head in self.heads:
+            # pass a copy of features to avoid in-place modifications between heads
+            x_copy = [xi.clone() for xi in x]
+            outputs.append(head(x_copy))
+        return outputs

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -61,6 +61,7 @@ from ultralytics.nn.modules import (
     Segment,
     WorldDetect,
     v10Detect,
+    MultiTaskDetect,
 )
 from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, colorstr, emojis, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
@@ -1044,7 +1045,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
             args = [ch[f]]
         elif m is Concat:
             c2 = sum(ch[x] for x in f)
-        elif m in {Detect, WorldDetect, Segment, Pose, OBB, ImagePoolingAttn, v10Detect}:
+        elif m in {Detect, WorldDetect, Segment, Pose, OBB, ImagePoolingAttn, v10Detect, MultiTaskDetect}:
             args.append([ch[x] for x in f])
             if m is Segment:
                 args[2] = make_divisible(min(args[2], max_channels) * width, 8)


### PR DESCRIPTION
## Summary
- implement `MultiTaskDetect` to support multiple detection heads
- register `MultiTaskDetect` module
- enable YAML model definition with `MultiTaskDetect`
- add sample multitask config
- test MultiTaskDetect forward pass

## Testing
- `pytest tests/test_multitask.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cee319e8832ab71e6cc68c7733e1